### PR TITLE
Generate GitHub CI workflow for building and publishing Docker image to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,37 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: .docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/yurzs/ollama-x:latest
+            ghcr.io/yurzs/ollama-x:${{ github.ref_name }}
+          platforms: linux/amd64,linux/arm64

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,4 @@
-
 DOCKERFILE := .docker/Dockerfile
-
-publish:
-	docker buildx build \
-		-f $(DOCKERFILE) \
-		--platform linux/amd64,linux/arm64 \
-		-t ghcr.io/yurzs/ollama-x:latest \
-		--push \
-		.
 
 format:
 	@poetry run ruff format


### PR DESCRIPTION
Add GitHub Actions workflow to build and publish Docker image to GitHub Container Registry.

* **Makefile**
  - Remove the `publish` target.

* **.github/workflows/docker-publish.yml**
  - Create a new workflow file to build and publish the Docker image.
  - Trigger the workflow on push to the `master` branch and on new tags.
  - Use the `secrets.GITHUB_TOKEN` for authentication to GitHub Container Registry.
  - Build Docker images for linux/amd64 and linux/arm64 architectures.
  - Tag the Docker image with both `latest` and the tag name.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Yurzs/ollama-x/pull/3?shareId=b2c3cc93-2923-4f38-8525-4d7d3acd8480).