### PR TITLE
ci: add GitHub Actions workflow for publishing DevContainer images

### DIFF
--- a/.github/workflows/devcontainer-publish.yml
+++ b/.github/workflows/devcontainer-publish.yml
@@ -1,0 +1,60 @@
+name: Publish DevContainer Images
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - '.devcontainer/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        component: [frontend, backend]
+        include:
+          - component: frontend
+            dockerfile: .devcontainer/frontend.Dockerfile
+            image: ghcr.io/yurzs/ollama-x-dev-frontend
+          - component: backend
+            dockerfile: .devcontainer/backend.Dockerfile
+            image: ghcr.io/yurzs/ollama-x-dev-backend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=sha,format=short
+            latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the publishing of DevContainer images for both frontend and backend components. The workflow is triggered on pushes to the master branch and on demand via workflow dispatch.

Key changes include:

* [`.github/workflows/devcontainer-publish.yml`](diffhunk://#diff-e2f2117de882a3e5bb06c53950c1320866ec799b56261fb8a313c217fc2a2cb5R1-R60): Added a new workflow to build and publish Docker images for frontend and backend components using Docker Buildx and GitHub Container Registry. The workflow is triggered on pushes to the master branch and paths under `.devcontainer/**`.