### PR TITLE
ci: remove path restriction for DevContainer publish workflow

### DIFF
--- a/.github/workflows/devcontainer-publish.yml
+++ b/.github/workflows/devcontainer-publish.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - '.devcontainer/**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/devcontainer-publish.yml` file. The change removes the `paths` configuration under the `push` event, which previously specified that only changes within the `.devcontainer` directory would trigger the workflow.

* [`.github/workflows/devcontainer-publish.yml`](diffhunk://#diff-e2f2117de882a3e5bb06c53950c1320866ec799b56261fb8a313c217fc2a2cb5L7-L8): Removed the `paths` configuration under the `push` event to allow the workflow to be triggered by any changes to the `master` branch.