### PR TITLE
feat: Distroless image

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:3.12-alpine
+ARG debug=0
+
+FROM python:3.12-slim AS builder
 
 # Install the required packages
-RUN apk add --no-cache gcc musl-dev linux-headers
+RUN apt update && apt install -y gcc musl-dev
 
 # Install dependencies
 RUN pip install poetry
@@ -18,6 +20,17 @@ COPY README.md .
 # Install the dependencies
 RUN poetry install
 
-ENTRYPOINT ["poetry", "run"]
+FROM gcr.io/distroless/python3-debian12:${debug:+debug-}nonroot
 
-CMD ["python", "-m", "uvicorn", "ollama_x.app:app", "--host", "0.0.0.0"]
+COPY --from=builder /app /app
+COPY --from=builder /usr/local/lib /usr/local/lib
+COPY --from=builder /usr/local/bin /usr/local/bin
+COPY --from=builder /etc/ld.so.cache /etc/ld.so.cache
+
+WORKDIR /app
+
+ENV PATH="/app/.venv/bin:${PATH}"
+
+ENTRYPOINT []
+
+CMD ["uvicorn", "ollama_x.app:app", "--host", "0.0.0.0"]


### PR DESCRIPTION
This pull request includes significant changes to the `.docker/Dockerfile` to improve the build process and optimize the resulting Docker image. The most important changes include switching to a multi-stage build, modifying the base image, and updating the installation and entrypoint commands.

Improvements to the Docker build process:

* Switched to a multi-stage build to separate the build environment from the final runtime environment. This helps to reduce the size of the final Docker image.
* Changed the base image from `python:3.12-alpine` to `python:3.12-slim` for the builder stage and `gcr.io/distroless/python3-debian12` for the final stage. This change aims to provide a more secure and minimal runtime environment. [[1]](diffhunk://#diff-38801fa32c4bd7bd97aa3c87c138be36e126e0337b22aacf27ab57365357dc20L1-R6) [[2]](diffhunk://#diff-38801fa32c4bd7bd97aa3c87c138be36e126e0337b22aacf27ab57365357dc20L21-R36)
* Updated the package installation commands to use `apt` instead of `apk`, aligning with the new base image.
* Modified the entrypoint and command to use `uvicorn` directly, removing the dependency on `poetry` for running the application.
* Added an `ARG` for `debug` mode to allow for easier debugging during the build process.