### PR TITLE
feat: add workflow step to build and push Debug Docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,3 +35,16 @@ jobs:
             ghcr.io/yurzs/ollama-x:latest
             ghcr.io/yurzs/ollama-x:${{ github.ref_name }}
           platforms: linux/amd64,linux/arm64
+
+      - name: Build and push Debug Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: .docker/Dockerfile
+          push: true
+          build-args: |
+            debug=1
+          tags: |
+            ghcr.io/yurzs/ollama-x:latest-debug
+            ghcr.io/yurzs/ollama-x:${{ github.ref_name }}-debug
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/docker-publish.yml` file to add a new job for building and pushing a debug version of the Docker image.

* Added a new job to build and push a Debug Docker image using `docker/build-push-action@v2`. This job includes specific build arguments and tags for the debug version of the image. (`.github/workflows/docker-publish.yml`)