### PR TITLE
feat: update backend image in docker-compose.yml to use new repository path

### DIFF
--- a/.devcontainer/frontend/docker-compose.yml
+++ b/.devcontainer/frontend/docker-compose.yml
@@ -17,12 +17,11 @@ services:
       - backend
 
   backend:
-    image: ghcr.io/yurzs/ollama-x-dev-backend:latest
+    image: ghcr.io/yurzs/ollama-x:latest
     pull_policy: always
     volumes:
       - ../..:/app:cached
       - backend-venv:/app/.venv
-    command: sleep infinity
     environment:
       MONGO_URI: mongodb://root:example@mongo:27017
       LANGFUSE_HOST: ${LF_HOST}


### PR DESCRIPTION
This pull request includes a change to the `services` section in the `.devcontainer/frontend/docker-compose.yml` file. The most important change is the update to the backend image configuration.

Backend configuration update:

* [`.devcontainer/frontend/docker-compose.yml`](diffhunk://#diff-25b7318ad94b2708dd9442c2273143096db56f34eb27932e76ca85e9dfdc88daL20-L25): Changed the backend image from `ghcr.io/yurzs/ollama-x-dev-backend:latest` to `ghcr.io/yurzs/ollama-x:latest` and removed the `command: sleep infinity` line.