### PR TITLE
feat: update Dockerfile to use 'uv sync' for virtual environment setup

### DIFF
--- a/.docker/Dockerfile
+++ b/.docker/Dockerfile
@@ -13,9 +13,7 @@ COPY ollama_x ollama_x
 COPY README.md .
 
 # Create virtual environment and install dependencies
-RUN uv venv .venv \
-    && . .venv/bin/activate \
-    && uv pip install -e .
+RUN uv sync --extra dev
 
 FROM gcr.io/distroless/python3-debian12:${debug:+debug-}nonroot
 COPY --from=builder /app /app


### PR DESCRIPTION
This pull request includes a change to the `.docker/Dockerfile` to streamline the setup process for the virtual environment and dependencies.

* [`.docker/Dockerfile`](diffhunk://#diff-38801fa32c4bd7bd97aa3c87c138be36e126e0337b22aacf27ab57365357dc20L16-R16): Replaced the commands for creating a virtual environment and installing dependencies with a single `uv sync --extra dev` command.