### PR TITLE
feat: update ruff and openapi-cli versions in optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,8 +30,8 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "plumbum>=1.8.3",
-    "ruff>=0.6.2",
-    "openapi-cli[full]>=0.2",
+    "ruff>=0.4",
+    "openapi-cli[full]>=0.2.1.14",
     "types-python-jose>=3.4.0.20250224",
     "types-passlib>=1.7.7.20241221"
 ]


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change updates the versions of the `ruff` and `openapi-cli[full]` dependencies.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L33-R34): Updated `ruff` version from `>=0.6.2` to `>=0.4`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L33-R34): Updated `openapi-cli[full]` version from `>=0.2` to `>=0.2.1.14`.